### PR TITLE
Add quick heading regenerate workflow

### DIFF
--- a/QuickHeadingRegenerate.js
+++ b/QuickHeadingRegenerate.js
@@ -1,0 +1,349 @@
+(function () {
+  const existing = window.__CBGQuickRegen;
+  if (existing && existing.initialized) {
+    if (typeof existing.updateData === "function") {
+      existing.updateData(window.__CBGQuickRegenData || null);
+    }
+    return;
+  }
+
+  const BUTTON_CLASS = "heading-regenerate";
+  const BLOCK_CLASS = "cbg-quick-regen-block";
+  const ANCHOR_SELECTOR = ".heading-input-anchor";
+  const TOAST_CLASS = "quick-regen-toast";
+  const config = { webhook: "", body: null, envelope: null };
+  const anchorRegistry = new Map();
+  const inflight = new Map();
+
+  function deepClone(value) {
+    if (value == null) {
+      return value;
+    }
+    try {
+      return JSON.parse(JSON.stringify(value));
+    } catch (err) {
+      return value;
+    }
+  }
+
+  function updateConfig(data) {
+    if (!data || typeof data !== "object") {
+      return;
+    }
+    if (typeof data.webhook === "string") {
+      config.webhook = data.webhook;
+    }
+    if (data.body) {
+      config.body = deepClone(data.body);
+    }
+    if (data.envelope) {
+      config.envelope = deepClone(data.envelope);
+    }
+  }
+
+  function cleanupAnchors() {
+    anchorRegistry.forEach((anchor, key) => {
+      if (!anchor || !anchor.isConnected) {
+        anchorRegistry.delete(key);
+      }
+    });
+  }
+
+  function findMarkerBlock(anchor) {
+    if (!anchor) return null;
+    const markdownBlock = anchor.closest('[data-testid="stMarkdown"]');
+    return markdownBlock || anchor.parentElement;
+  }
+
+  function findInputBlock(anchor) {
+    const markerBlock = findMarkerBlock(anchor);
+    let node = markerBlock;
+    while (node) {
+      let sibling = node.nextElementSibling;
+      while (sibling) {
+        if (sibling.matches && sibling.matches('[data-testid="stTextInput"]')) {
+          return sibling;
+        }
+        if (sibling.querySelector && sibling.querySelector('input')) {
+          return sibling;
+        }
+        sibling = sibling.nextElementSibling;
+      }
+      node = node.parentElement;
+    }
+    return null;
+  }
+
+  function getInputElement(block) {
+    if (!block) return null;
+    return block.querySelector('input');
+  }
+
+  function setLoading(button, loading) {
+    if (!button) return;
+    if (loading) {
+      button.classList.add('is-loading');
+      button.disabled = true;
+    } else {
+      button.classList.remove('is-loading');
+      button.disabled = false;
+    }
+  }
+
+  function showToast(message) {
+    if (!message) return;
+    const toast = document.createElement('div');
+    toast.className = TOAST_CLASS;
+    toast.textContent = message;
+    document.body.appendChild(toast);
+    requestAnimationFrame(() => {
+      toast.classList.add('is-visible');
+    });
+    setTimeout(() => {
+      toast.classList.remove('is-visible');
+      setTimeout(() => {
+        if (toast.parentNode) {
+          toast.parentNode.removeChild(toast);
+        }
+      }, 260);
+    }, 4000);
+  }
+
+  function generateRequestId() {
+    if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+      return window.crypto.randomUUID();
+    }
+    return 'req-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 10);
+  }
+
+  function buildEnvelope(body) {
+    if (!body) return null;
+    const env = config.envelope ? deepClone(config.envelope) : {};
+    const envelope = {
+      headers: env && env.headers ? env.headers : {},
+      params: env && env.params ? env.params : {},
+      query: env && env.query ? env.query : {},
+      body: body,
+    };
+    if (env && Object.prototype.hasOwnProperty.call(env, 'webhookUrl')) {
+      envelope.webhookUrl = env.webhookUrl;
+    }
+    if (env && Object.prototype.hasOwnProperty.call(env, 'executionMode')) {
+      envelope.executionMode = env.executionMode;
+    }
+    return [envelope];
+  }
+
+  function syncAnchor(anchor) {
+    if (!anchor || !(anchor instanceof HTMLElement)) {
+      return;
+    }
+    const anchorKey = anchor.dataset.anchorKey || anchor.dataset.headingId || '';
+    if (anchorKey) {
+      anchorRegistry.set(anchorKey, anchor);
+    }
+    const block = findInputBlock(anchor);
+    if (!block) {
+      return;
+    }
+    const locked = anchor.dataset.locked === 'true';
+    const existingButton = block.querySelector('.' + BUTTON_CLASS);
+    if (locked) {
+      block.classList.remove(BLOCK_CLASS);
+      if (existingButton) {
+        existingButton.remove();
+      }
+      return;
+    }
+    block.classList.add(BLOCK_CLASS);
+    let button = existingButton;
+    if (!button) {
+      button = document.createElement('button');
+      button.type = 'button';
+      button.className = BUTTON_CLASS;
+      button.setAttribute('aria-label', 'Regenerate heading');
+      button.title = 'Regenerate heading';
+      button.textContent = '🔁';
+      block.appendChild(button);
+    }
+    button.dataset.anchorKey = anchorKey;
+    button.dataset.headingId = anchor.dataset.headingId || '';
+    button.dataset.sectionPath = anchor.dataset.sectionPath || '';
+    button.dataset.headingLevel = anchor.dataset.headingLevel || '';
+  }
+
+  function refreshAnchors() {
+    cleanupAnchors();
+    document.querySelectorAll(ANCHOR_SELECTOR).forEach(syncAnchor);
+  }
+
+  function handleClick(event) {
+    const button = event.target.closest('.' + BUTTON_CLASS);
+    if (!button) return;
+    const anchorKey = button.dataset.anchorKey || button.dataset.headingId || '';
+    const anchor = anchorKey ? anchorRegistry.get(anchorKey) : null;
+    if (!anchor || !anchor.isConnected) {
+      refreshAnchors();
+      return;
+    }
+    if (anchor.dataset.locked === 'true') {
+      return;
+    }
+    const block = findInputBlock(anchor);
+    const input = getInputElement(block);
+    if (!input) {
+      showToast('Unable to locate heading input.');
+      return;
+    }
+    if (!config.webhook) {
+      showToast('Quick regenerate webhook is not configured.');
+      return;
+    }
+    const baseBody = deepClone(config.body);
+    if (!baseBody) {
+      showToast('Unable to build request payload.');
+      return;
+    }
+    const requestId = generateRequestId();
+    const headingId = anchor.dataset.headingId || '';
+    const sectionPath = anchor.dataset.sectionPath || '';
+    const headingLevel = (anchor.dataset.headingLevel || '').toUpperCase();
+    baseBody['Heading To Regenerate'] = input.value || '';
+    if (headingId) {
+      baseBody.heading_id = headingId;
+    }
+    if (sectionPath) {
+      baseBody.section_path = sectionPath;
+    }
+    if (headingLevel) {
+      baseBody.heading_level = headingLevel;
+    }
+    baseBody.request_id = requestId;
+    baseBody.timestamp = Date.now();
+
+    const payload = buildEnvelope(baseBody);
+    if (!payload) {
+      showToast('Unable to assemble request.');
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    setLoading(button, true);
+    const inflightKey = headingId || sectionPath || requestId;
+    inflight.set(inflightKey, requestId);
+
+    fetch(config.webhook, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }).then(async (response) => {
+      const finish = () => {
+        if (inflight.get(inflightKey) === requestId) {
+          inflight.delete(inflightKey);
+        }
+        setLoading(button, false);
+      };
+      if (!response.ok) {
+        let message = 'Failed to regenerate heading.';
+        try {
+          const errorData = await response.json();
+          if (errorData && typeof errorData.error === 'string') {
+            message = errorData.error;
+          } else if (response.status) {
+            message = `Failed to regenerate heading (HTTP ${response.status}).`;
+          }
+        } catch (err) {
+          if (response.status) {
+            message = `Failed to regenerate heading (HTTP ${response.status}).`;
+          }
+        }
+        finish();
+        showToast(message);
+        return;
+      }
+      let data;
+      try {
+        data = await response.json();
+      } catch (err) {
+        finish();
+        showToast('Received invalid response from automation.');
+        return;
+      }
+      if (inflight.get(inflightKey) !== requestId) {
+        finish();
+        return;
+      }
+      if (data && data.request_id && data.request_id !== requestId) {
+        finish();
+        return;
+      }
+      if (data && data.heading_id && headingId && data.heading_id !== headingId) {
+        finish();
+        return;
+      }
+      if (data && data.section_path && sectionPath && data.section_path !== sectionPath) {
+        finish();
+        return;
+      }
+      if (!data || typeof data.new_heading !== 'string') {
+        finish();
+        showToast('Automation did not return a heading.');
+        return;
+      }
+      const newHeading = data.new_heading;
+      if (input.value !== newHeading) {
+        input.value = newHeading;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+      finish();
+    }).catch((error) => {
+      if (inflight.get(inflightKey) === requestId) {
+        inflight.delete(inflightKey);
+      }
+      setLoading(button, false);
+      showToast('Unable to reach quick regenerate service.');
+      console.error('Quick regenerate error:', error);
+    });
+  }
+
+  function handleUpdate() {
+    if (window.__CBGQuickRegenData) {
+      updateConfig(window.__CBGQuickRegenData);
+      refreshAnchors();
+    }
+  }
+
+  document.addEventListener('click', handleClick, true);
+
+  const observer = new MutationObserver(() => {
+    refreshAnchors();
+  });
+  if (document.body) {
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  if (window.__CBGQuickRegenData) {
+    updateConfig(window.__CBGQuickRegenData);
+  }
+  requestAnimationFrame(() => {
+    refreshAnchors();
+  });
+
+  window.addEventListener('cbg:update-quick-regen', handleUpdate);
+
+  window.__CBGQuickRegen = {
+    initialized: true,
+    refresh: refreshAnchors,
+    updateData: (data) => {
+      if (data) {
+        updateConfig(data);
+      } else if (window.__CBGQuickRegenData) {
+        updateConfig(window.__CBGQuickRegenData);
+      }
+      refreshAnchors();
+    },
+    showToast: showToast,
+  };
+})();

--- a/styles.css
+++ b/styles.css
@@ -201,6 +201,89 @@ div[role="radiogroup"] input:checked + div {
   overflow: hidden;
 }
 
+.heading-input-anchor {
+  display: none !important;
+}
+
+.cbg-quick-regen-block {
+  position: relative;
+}
+
+.cbg-quick-regen-block input {
+  padding-right: 48px !important;
+}
+
+.heading-regenerate {
+  position: absolute;
+  top: 50%;
+  right: 12px;
+  transform: translateY(-50%);
+  background: #151525;
+  border: 1px solid #2f2f4a;
+  border-radius: 50%;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text);
+  font-size: 16px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  z-index: 3;
+}
+
+.heading-regenerate:hover {
+  border-color: #3d3d60;
+  box-shadow: 0 0 10px rgba(110,231,255,0.22);
+  transform: translateY(-50%) scale(1.04);
+}
+
+.heading-regenerate:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.heading-regenerate.is-loading {
+  color: transparent;
+}
+
+.heading-regenerate.is-loading::after {
+  content: "";
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(110,231,255,0.55);
+  border-top-color: transparent;
+  animation: heading-regenerate-spin 0.8s linear infinite;
+}
+
+@keyframes heading-regenerate-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.quick-regen-toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  background: rgba(15, 15, 22, 0.92);
+  border: 1px solid #2f2f4a;
+  padding: 12px 16px;
+  border-radius: 10px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  color: var(--text);
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.22s ease, transform 0.22s ease;
+  z-index: 9999;
+}
+
+.quick-regen-toast.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 .sidebar-jump-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- inject heading metadata and quick-regenerate configuration so the frontend can target individual headings
- add a dedicated QuickHeadingRegenerate.js module that posts to the alternate webhook and safely applies returned headings
- style the inline regenerate button, loading state, and toast feedback

## Testing
- python -m compileall app.py QuickHeadingRegenerate.js

------
https://chatgpt.com/codex/tasks/task_e_68de8fd8890c8330913a3c7bb4a5b987